### PR TITLE
fix: lazy init and infinite recursion fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Based on [Officially Supported Databases](https://docs.djangoproject.com/en/3.0/
 pip install casbin-django-orm-adapter
 ```
 
-Add `casbin_adapter.apps.CasbinAdapterConfig` to your `INSTALLED_APPS`
+Add `casbin_adapter` to your `INSTALLED_APPS`
 
 ```python
 # settings.py
@@ -36,7 +36,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 INSTALLED_APPS = [
     ...
-    'casbin_adapter.apps.CasbinAdapterConfig',
+    'casbin_adapter',
     ...
 ]
 

--- a/casbin_adapter/apps.py
+++ b/casbin_adapter/apps.py
@@ -4,3 +4,7 @@ from django.conf import settings
 
 class CasbinAdapterConfig(AppConfig):
     name = "casbin_adapter"
+
+    def ready(self):
+        from .enforcer import enforcer
+        enforcer.db_alias = getattr(settings, "CASBIN_DB_ALIAS", "default")

--- a/casbin_adapter/apps.py
+++ b/casbin_adapter/apps.py
@@ -4,9 +4,3 @@ from django.conf import settings
 
 class CasbinAdapterConfig(AppConfig):
     name = "casbin_adapter"
-
-    def ready(self):
-        from .enforcer import initialize_enforcer
-
-        db_alias = getattr(settings, "CASBIN_DB_ALIAS", "default")
-        initialize_enforcer(db_alias)

--- a/casbin_adapter/enforcer.py
+++ b/casbin_adapter/enforcer.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class ProxyEnforcer(Enforcer):
     _initialized = False
-    db_alias = "default"
+    db_alias = getattr(settings, "CASBIN_DB_ALIAS", "default")
 
     def __init__(self, *args, **kwargs):
         if self._initialized:
@@ -43,9 +43,9 @@ class ProxyEnforcer(Enforcer):
                 self.set_role_manager(role_manager)
 
     def __getattribute__(self, name):
-        safe_methods = ["__init__", "_load", "_initialized"]
+        safe_methods = ["__init__", "_load", "_initialized", "__class__"]
         if not super().__getattribute__("_initialized") and name not in safe_methods:
-            initialize_enforcer(self.db_alias)
+            initialize_enforcer(super().__getattribute__("db_alias"))
             if not super().__getattribute__("_initialized"):
                 raise Exception(
                     (

--- a/casbin_adapter/enforcer.py
+++ b/casbin_adapter/enforcer.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class ProxyEnforcer(Enforcer):
     _initialized = False
-    db_alias = getattr(settings, "CASBIN_DB_ALIAS", "default")
+    db_alias = "default"
 
     def __init__(self, *args, **kwargs):
         if self._initialized:
@@ -43,7 +43,7 @@ class ProxyEnforcer(Enforcer):
                 self.set_role_manager(role_manager)
 
     def __getattribute__(self, name):
-        safe_methods = ["__init__", "_load", "_initialized", "__class__"]
+        safe_methods = ["__init__", "__class__", "_load", "_initialized", "db_alias"]
         if not super().__getattribute__("_initialized") and name not in safe_methods:
             initialize_enforcer(super().__getattribute__("db_alias"))
             if not super().__getattribute__("_initialized"):


### PR DESCRIPTION
Hi, I have two fixes for the adapter:
1. Accessing database in `ready` is discouraged by Django, since `ProxyEnforcer` lazy-initializes Casbin anyway, initialization should be removed from `CasbinAdapterConfig`.
2. Infinite recursion in `__getattribute__(self, name)` caused by `self.db_alias`. Also, If `enforcer` is imported in testing environment it breaks Django's test runner which calls `__class__` on every imported module during test discovery.